### PR TITLE
Set resolve_reference task to private

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## Release 0.1.1
+
+### Bug fixes
+
+* **Set `resolve_reference` task to private**
+
+  The `resolve_reference` task has been set to private so it no longer appears in UI lists.
+
 ## Release 0.1.0
 
 This is the initial release.

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "puppetlabs-gcloud_inventory",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "author": "Puppet, Inc.",
   "summary": "A task to generate Bolt inventory from Google Cloud compute engine instances",
   "license": "Apache-2.0",

--- a/tasks/resolve_reference.json
+++ b/tasks/resolve_reference.json
@@ -17,5 +17,6 @@
     "target_mapping": {
       "type": "Hash"
     }
-  }
+  },
+  "private": true
 }


### PR DESCRIPTION
This sets the `resolve_reference` task to private so it does not appear
in UI lists, similar to other `resolve_reference` tasks.