### PR TITLE
(bug) Add missing dependencies to metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## Release 0.1.2
+
+### Bug fixes
+
+* **Add missing dependencies to module metadata**
+  ([#6](https://github.com/puppetlabs/puppetlabs-gcloud_inventory/pull/6))
+
+  The module metadata now includes `ruby_plugin_helper` and `ruby_task_helper`
+  as dependencies.
+
 ## Release 0.1.1
 
 ### Bug fixes

--- a/metadata.json
+++ b/metadata.json
@@ -1,13 +1,20 @@
 {
   "name": "puppetlabs-gcloud_inventory",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "author": "Puppet, Inc.",
   "summary": "A task to generate Bolt inventory from Google Cloud compute engine instances",
   "license": "Apache-2.0",
   "source": "git@github.com/puppetlabs/puppetlabs-gcloud_inventory",
   "project_page": "https://github.com/puppetlabs/puppetlabs-gcloud_inventory",
   "dependencies": [
-
+    {
+      "name":"puppetlabs-ruby_plugin_helper",
+      "version_requirement":">= 0.1.0 < 1.0.0"
+    },
+    {
+      "name":"puppetlabs-ruby_task_helper",
+      "version_requirement":">= 0.4.0 < 1.0.0"
+    }
   ],
   "operatingsystem_support": [
     {

--- a/tasks/resolve_reference.json
+++ b/tasks/resolve_reference.json
@@ -1,7 +1,8 @@
 {
   "description": "Generate targets from Google Cloud compute engine instances",
-  "files": ["ruby_task_helper/files/task_helper.rb",
-            "ruby_plugin_helper/lib/plugin_helper.rb"
+  "files": [
+    "ruby_task_helper/files/task_helper.rb",
+    "ruby_plugin_helper/lib/plugin_helper.rb"
   ],
   "input_method": "stdin",
   "parameters": {


### PR DESCRIPTION
This adds `ruby_task_helper` and `ruby_plugin_helper` as dependencies in
the module metadata.