### PR TITLE
(maint) Add PDK as a dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## Release 0.1.3
+
+### Bug fixes
+
+* **Add PDK as a gem dependency**
+
+  PDK is now a gem dependency for the module release pipeline
+
 ## Release 0.1.2
 
 ### Bug fixes

--- a/Gemfile
+++ b/Gemfile
@@ -20,6 +20,7 @@ minor_version = ruby_version_segments[0..1].join('.')
 group :development do
   gem "puppet-module-posix-default-r#{minor_version}", require: false, platforms: [:ruby]
   gem "puppet-module-posix-dev-r#{minor_version}",     require: false, platforms: [:ruby]
+  gem "pdk", *location_for(ENV['PDK_GEM_VERSION'])
   gem 'puppet', *location_for(ENV['PUPPET_GEM_VERSION'])
   # Pin puppet blacksmith to avoid failures in forge module push job
   gem "puppet-blacksmith", "4.1.2"

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "puppetlabs-gcloud_inventory",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "author": "Puppet, Inc.",
   "summary": "A task to generate Bolt inventory from Google Cloud compute engine instances",
   "license": "Apache-2.0",


### PR DESCRIPTION
Running the module release pipeline is causing the error `Errno::ENOENT:
No such file or directory - pdk`, which is the same issue described [in
this
commit](https://github.com/puppetlabs/puppetlabs-puppet_agent/pull/507).
Adding PDK as a depedency should ensure that the new release rake task
succeeds.

This also preps to release 0.1.3