### PR TITLE
(PE-31356) Add individual creds fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,9 @@ and zone. It supports the following fields:
 | Option | Type | Description |
 | ------ | ---- | ----------- |
 | `credentials` | `String` | A path to the service account credentials file. Accepts either an absolute path or a path relative to the Bolt project directory. _Optional._ |
+| `client_email` | `String` | The Google Cloud client email to use. _Optional_. |
+| `token_uri` | `String` | The Google Cloud token uri to use. _Optional_. |
+| `private_key` | `String` | The Google Cloud private key to use. _Optional_. |
 | `project` | `String` | The name of the project to lookup instances from. _Required_. |
 | `target_mapping` | `Hash` | A hash of target attributes to populate with resource values. Must include either `name` or `uri`. _Required_. |
 | `zone` | `String` | The name of the zone to lookup instances from. _Required_. |
@@ -33,9 +36,10 @@ and zone. It supports the following fields:
 
 The plugin supports loading a credentials file from a path specified in either the `credentials` option
 or the `GOOGLE_APPLICATION_CREDENTIALS` environment variable. A path specified in the `credentials`
-option will take precedence over a path specified in the `GOOGLE_APPLICATION_CREDENTIALS` environment
-variable. If a credentials file is not specified, or the path does not point to a valid credentials
-file, the plugin will error.
+ption or credentials specified in the `client_email`, `token_uri` and `private_key` fields will take
+precedence over a path specified in the `GOOGLE_APPLICATION_CREDENTIALS` environment variable. If a
+credentials file is not specified, or the path does not point to a valid credentials file, the plugin
+will error.
 
 The credentials file must contain a JSON object with at least the following fields:
 

--- a/spec/tasks/resolve_reference_spec.rb
+++ b/spec/tasks/resolve_reference_spec.rb
@@ -95,6 +95,14 @@ describe GCloudInventory do
       allow(File).to receive(:read).and_return('"data"')
       expect { subject.credentials(opts) }.to raise_error(TaskHelper::Error, /Expected credentials to be a Hash/)
     end
+
+    it 'correctly builds the credentials hash when creds are passed in' do
+      opts.delete(:credentials)
+      provided_creds = { client_email: 'testemail',
+                         token_uri: 'tokenuri',
+                         private_key: 'privatekey' }
+      expect(subject.credentials(opts.merge(provided_creds))).to eq(provided_creds.transform_keys(&:to_s))
+    end
   end
 
   describe '#get_all_instances' do

--- a/tasks/resolve_reference.json
+++ b/tasks/resolve_reference.json
@@ -15,6 +15,16 @@
     "credentials": {
       "type": "Optional[String[1]]"
     },
+    "client_email": {
+      "type": "Optional[String[1]]"
+    },
+    "token_uri": {
+      "type": "Optional[String[1]]"
+    },
+    "private_key": {
+      "type": "Optional[String[1]]",
+      "sensitive": true
+    },
     "target_mapping": {
       "type": "Hash"
     }


### PR DESCRIPTION
This commit adds the `client_email`, `token_uri` and
`private_key` fields to the plugin to allow users to pass in the
relevant credentials directly rather than using a file. This is to avoid
relying on external files/variables for the task. If a credentials file
is provided, it will take precedence over these new credential
parameters.