### PR TITLE
(BOLT-136) Bump ruby_task_helper upper bound to < 2.0.0

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -2,10 +2,10 @@ name: Tests
 
 on:
   push:
-    branches: [master]
+    branches: [main]
     paths-ignore: ['*.md']
   pull_request:
-    type: [opened, reopened, edited]
+    types: [opened, reopened, edited]
     paths-ignore: ['*.md']
 
 jobs:
@@ -15,24 +15,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v1
+        uses: actions/checkout@v4
       - name: Setup Ruby
-        uses: actions/setup-ruby@v1
+        uses: ruby/setup-ruby@v1
         with:
-          ruby-version: '2.5.x'
-      - name: Install bundler
-        run: |
-          gem install bundler
-          bundle config path vendor/bundle
-      - name: Cache gems
-        id: cache
-        uses: actions/cache@v1
-        with:
-          path: vendor/bundle
-          key: ${{ runner.os }}-gems-${{ hashFiles('**/Gemfile') }}
-      - name: Install gems
-        if: steps.cache.outputs.cache-hit != 'true'
-        run: bundle install --jobs 4 --retry 3
+          ruby-version: '3.1'
+          bundler-cache: true
       - name: Clone helpers
         run: |
           git clone https://github.com/puppetlabs/puppetlabs-ruby_task_helper ../ruby_task_helper
@@ -45,11 +33,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v1
+        uses: actions/checkout@v4
       - name: Setup Ruby
-        uses: actions/setup-ruby@v1
+        uses: ruby/setup-ruby@v1
         with:
-          ruby-version: '2.5.x'
+          ruby-version: '3.1'
       - name: Install rubocop
         run: gem install rubocop
       - name: Run rubocop

--- a/metadata.json
+++ b/metadata.json
@@ -13,7 +13,7 @@
     },
     {
       "name":"puppetlabs-ruby_task_helper",
-      "version_requirement":">= 0.4.0 < 1.0.0"
+      "version_requirement":">= 0.4.0 < 2.0.0"
     }
   ],
   "operatingsystem_support": [


### PR DESCRIPTION
## Summary

Bumps the `ruby_task_helper` dependency upper bound in `metadata.json` from `< 1.0.0` to `< 2.0.0`, keeping the original lower bound: `>= 0.4.0 < 1.0.0` → `>= 0.4.0 < 2.0.0`. Also modernizes the CI workflow to use current GitHub Actions and Ruby 3.1.

## Background — BOLT-136

Bolt 5.x ships `ruby_task_helper 1.0.1` (pinned in bolt-private's Puppetfile). Modules that declare an upper bound of `< 1.0.0` on `ruby_task_helper` cause a dependency resolution failure when users run `bolt module install`:

```
Unable to resolve modules: Puppetfile Resolver could not find compatible versions
for possibility named "ruby_task_helper":
  puppetlabs-ruby_task_helper 1.0.1
  puppetlabs-gcloud_inventory depends on puppetlabs-ruby_task_helper >= 0.4.0 < 1.0.0
```

This blocks Puppet 8 / Bolt 5 users from installing any module bundle that includes this module alongside `ruby_task_helper >= 1.0.0`.

## Changes

### 1. Dependency constraint (metadata.json)

```diff
- "version_requirement": ">= 0.4.0 < 1.0.0"
+ "version_requirement": ">= 0.4.0 < 2.0.0"
```

The upper bound is bumped to `< 2.0.0` (SemVer-aligned) to unblock `ruby_task_helper` 1.x while still guarding against a hypothetical breaking 2.x release.

### 2. CI modernization (tests.yaml)

The existing CI workflow was broken due to deprecated/removed actions and EOL Ruby:

- `actions/checkout@v1` → `actions/checkout@v4`
- `actions/setup-ruby@v1` → `ruby/setup-ruby@v1` (with `bundler-cache: true`)
- `actions/cache@v1` → removed (replaced by `ruby/setup-ruby`'s built-in bundler cache)
- Ruby `2.5.x` (EOL since March 2021) → `3.1`
- Push trigger branch `master` → `main` (matches actual default branch)
- Fixed `pull_request` trigger: `type` → `types`

## How it was tested

### 1. Constraint verification (before fix)

Confirmed the constraint violation exists with the published Forge version:

```
$ bolt module install
Unable to resolve modules: Puppetfile Resolver could not find compatible versions
for possibility named "ruby_task_helper":
  puppetlabs-ruby_task_helper 1.0.1
  puppetlabs-gcloud_inventory depends on puppetlabs-ruby_task_helper >= 0.4.0 < 1.0.0
```

### 2. Cross-module Puppetfile resolution

Verified that all 5 affected modules resolve cleanly together with `ruby_task_helper 1.0.1` using bolt's Puppetfile resolver. This confirms no remaining constraint conflicts across the module set.

## Related PRs

This is one of 5 coordinated PRs across affected modules:
- [puppetlabs-azure_inventory #16](https://github.com/puppetlabs/puppetlabs-azure_inventory/pull/16)
- `puppetlabs-gcloud_inventory` (this PR)
- [puppetlabs-http_request #18](https://github.com/puppetlabs/puppetlabs-http_request/pull/18)
- [puppetlabs-vault #19](https://github.com/puppetlabs/puppetlabs-vault/pull/19)
- [puppetlabs-terraform #41](https://github.com/puppetlabs/puppetlabs-terraform/pull/41)

All apply the same change: bump the `ruby_task_helper` upper bound from `< 1.0.0` to `< 2.0.0`.